### PR TITLE
Rank distribution

### DIFF
--- a/architecture/Database/schema.database
+++ b/architecture/Database/schema.database
@@ -68,6 +68,8 @@ Table rank_history as RH {
   new_rank                  rank
   type                      rank_type
   reason                    text
+  distributor               integer [ref: > U.id]
+  contract                  integer [ref: > CT.id]
   created                   timestamp
   updated                   timestamp
 }

--- a/architecture/Database/schema.database
+++ b/architecture/Database/schema.database
@@ -61,6 +61,17 @@ Table contract_notifications as CN {
   updated                   timestamp
 }
 
+Table rank_history as RH {
+  id                        integer
+  adventurer                integer [ref: > U.id]
+  old_rank                  rank
+  new_rank                  rank
+  type                      rank_type
+  reason                    text
+  created                   timestamp
+  updated                   timestamp
+}
+
 Enum role {
   ROLE_ADMIN
   ROLE_CUSTOMER
@@ -83,6 +94,12 @@ Enum contract_status {
   Performed
   Completed
 }
+
+Enum rank_type {
+  Auto
+  Distributor
+}
+
 
 Enum rank {
   Platinum    // adventurer_experience for rank - 10000

--- a/architecture/OpenApi/api.yaml
+++ b/architecture/OpenApi/api.yaml
@@ -639,6 +639,67 @@ paths:
               schema:
                 $ref: '#/components/schemas/errorModel'
 
+  /api/v1/adventurers/{id}/ranks/history/:
+    # Получение списка авантюристов
+    get:
+      tags:
+        - adventurers
+      operationId: getAdventurerRankHistory
+      summary: Getting a list of rank history
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          description: 'User ID.'
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: List of rank history
+          content:
+            application-json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/paginationInfo'
+                  - type: object
+                    properties:
+                      items:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/rankHistoryModel'
+        '400':
+          description: Bad Reaquest.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/errorModel'
+        '401':
+          description: Unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/errorModel'
+        '403':
+          description: Forbidden.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/errorModel'
+        '404':
+          description: Not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/errorModel'
+        '500':
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/errorModel'
+
   /api/v1/account/notifications/:
     # Получить нотификации пользователя
     get:
@@ -1175,6 +1236,34 @@ components:
           type: string
           description: "Reason for changing rank"
           example: "Too weak."
+
+    rankHistoryModel:
+      type: object
+      properties:
+        oldRank:
+          $ref: '#/components/schemas/ranksModel'
+        newRank:
+          $ref: '#/components/schemas/ranksModel'
+        type:
+          $ref: '#/components/schemas/rankType'
+        reason:
+          type: string
+          description: "Reason for changing rank if type is Distributor"
+          example: "Too weak."
+        time:
+          description: 'Date the contract was created.'
+          type: string
+          format: date-time
+          example: '2017-07-21T17:32:28Z'
+
+    rankType:
+      description: 'Rank distribution type.'
+      type: string
+      enum:
+        - Auto
+        - Distributor
+      example:
+        Distributor
 
     role:
       description: 'User role in system. Define user privileges in the system.'

--- a/architecture/OpenApi/api.yaml
+++ b/architecture/OpenApi/api.yaml
@@ -655,6 +655,18 @@ paths:
           required: true
           schema:
             type: integer
+        - in: query
+          name: page
+          schema:
+            type: integer
+          required: false
+          description: Pagination parameter
+        - in: query
+          name: size
+          schema:
+            type: integer
+          required: false
+          description: Pagination parameter
       responses:
         '200':
           description: List of rank history

--- a/src/main/java/com/itmo/goblinslayersystemserver/controllers/AdventurersRestControllerV1.java
+++ b/src/main/java/com/itmo/goblinslayersystemserver/controllers/AdventurersRestControllerV1.java
@@ -2,19 +2,15 @@ package com.itmo.goblinslayersystemserver.controllers;
 
 import com.itmo.goblinslayersystemserver.dto.*;
 import com.itmo.goblinslayersystemserver.models.RankHistory;
-import com.itmo.goblinslayersystemserver.models.Role;
 import com.itmo.goblinslayersystemserver.models.User;
 import com.itmo.goblinslayersystemserver.models.enums.AdventurerRank;
 import com.itmo.goblinslayersystemserver.models.enums.AdventurerStatus;
-import com.itmo.goblinslayersystemserver.models.enums.RoleEnum;
 import com.itmo.goblinslayersystemserver.services.IUserService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
-import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 
-import java.util.Collections;
 import java.util.stream.Collectors;
 
 @RestController
@@ -93,7 +89,7 @@ public class AdventurersRestControllerV1 {
     public ItemsDto<AdventurerRankHistoryDto> getAdventurerRankHistory(@PathVariable Integer id,
                                                                        @RequestParam(defaultValue = "0") int page,
                                                                        @RequestParam(defaultValue = "5") int size) {
-        Page<RankHistory> usersPage = userService.getAdventurerRankHistory();
+        Page<RankHistory> usersPage = userService.getAdventurerRankHistory(id, page, size);
 
         return new ItemsDto<>(
                 usersPage.getNumber(),

--- a/src/main/java/com/itmo/goblinslayersystemserver/controllers/AdventurersRestControllerV1.java
+++ b/src/main/java/com/itmo/goblinslayersystemserver/controllers/AdventurersRestControllerV1.java
@@ -1,6 +1,7 @@
 package com.itmo.goblinslayersystemserver.controllers;
 
 import com.itmo.goblinslayersystemserver.dto.*;
+import com.itmo.goblinslayersystemserver.models.RankHistory;
 import com.itmo.goblinslayersystemserver.models.Role;
 import com.itmo.goblinslayersystemserver.models.User;
 import com.itmo.goblinslayersystemserver.models.enums.AdventurerRank;
@@ -79,5 +80,25 @@ public class AdventurersRestControllerV1 {
     @PutMapping(value = "/{id}/ranks/", consumes = {"application/json"}, produces = {"application/json"})
     public AdventurerDto updateAdventurerRank(@PathVariable Integer id, @RequestBody AdventurerRankUpdateDto adventurerRankUpdateDto) {
         throw new NotImplementedException();
+    }
+
+    /**
+     * Get запрос для истории рангов авантюриста из системы по его ID
+     **/
+    @GetMapping(value = "/{id}/ranks/history/", consumes = {"application/json"}, produces = {"application/json"})
+    public ItemsDto<AdventurerRankHistoryDto> getAdventurerRankHistory(@PathVariable Integer id,
+                                                                       @RequestParam(defaultValue = "0") int page,
+                                                                       @RequestParam(defaultValue = "5") int size) {
+        Page<RankHistory> usersPage = userService.getAdventurerRankHistory();
+
+        return new ItemsDto<>(
+                usersPage.getNumber(),
+                usersPage.getTotalElements(),
+                usersPage.getTotalPages(),
+                usersPage
+                        .getContent()
+                        .stream()
+                        .map(AdventurerRankHistoryDto::new)
+                        .collect(Collectors.toList()));
     }
 }

--- a/src/main/java/com/itmo/goblinslayersystemserver/controllers/AdventurersRestControllerV1.java
+++ b/src/main/java/com/itmo/goblinslayersystemserver/controllers/AdventurersRestControllerV1.java
@@ -10,6 +10,7 @@ import com.itmo.goblinslayersystemserver.models.enums.RoleEnum;
 import com.itmo.goblinslayersystemserver.services.IUserService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 
@@ -79,7 +80,10 @@ public class AdventurersRestControllerV1 {
      **/
     @PutMapping(value = "/{id}/ranks/", consumes = {"application/json"}, produces = {"application/json"})
     public AdventurerDto updateAdventurerRank(@PathVariable Integer id, @RequestBody AdventurerRankUpdateDto adventurerRankUpdateDto) {
-        throw new NotImplementedException();
+        String username = SecurityContextHolder.getContext().getAuthentication().getName();
+        User distributor = userService.get(username);
+
+        return new AdventurerDto(userService.updateAdventurerRank(id, adventurerRankUpdateDto, distributor));
     }
 
     /**

--- a/src/main/java/com/itmo/goblinslayersystemserver/dto/AdventurerRankHistoryDto.java
+++ b/src/main/java/com/itmo/goblinslayersystemserver/dto/AdventurerRankHistoryDto.java
@@ -1,0 +1,30 @@
+package com.itmo.goblinslayersystemserver.dto;
+
+import com.itmo.goblinslayersystemserver.models.RankHistory;
+import com.itmo.goblinslayersystemserver.models.enums.AdventurerRank;
+import com.itmo.goblinslayersystemserver.models.enums.RankHistoryType;
+import lombok.Data;
+import lombok.NonNull;
+
+import java.util.Date;
+
+@Data
+public class AdventurerRankHistoryDto {
+    @NonNull
+    private AdventurerRank oldRank;
+    @NonNull
+    private AdventurerRank newRank;
+    @NonNull
+    private RankHistoryType type;
+    private String reason;
+    @NonNull
+    private Date time;
+
+    public AdventurerRankHistoryDto(RankHistory history) {
+        oldRank = history.getOldRank();
+        newRank = history.getNewRank();
+        type = history.getType();
+        reason = history.getReason();
+        time = history.getCreated();
+    }
+}

--- a/src/main/java/com/itmo/goblinslayersystemserver/models/RankHistory.java
+++ b/src/main/java/com/itmo/goblinslayersystemserver/models/RankHistory.java
@@ -1,0 +1,48 @@
+package com.itmo.goblinslayersystemserver.models;
+
+import com.itmo.goblinslayersystemserver.models.enums.AdventurerRank;
+import com.itmo.goblinslayersystemserver.models.enums.RankHistoryType;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+import javax.persistence.*;
+
+@EqualsAndHashCode(callSuper = true)
+@Entity
+@Table(name = "rank_history")
+@Data
+public class RankHistory extends BaseEntity {
+    /**
+     * ID авантюриста
+     **/
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "adventurer")
+    private User adventurer;
+
+    /**
+     * Старый ранг (с которого изменили)
+     **/
+    @Column(name="old_rank")
+    @Enumerated(EnumType.STRING)
+    private AdventurerRank oldRank;
+
+    /**
+     * Новый ранг (на который изменили)
+     **/
+    @Column(name="new_rank")
+    @Enumerated(EnumType.STRING)
+    private AdventurerRank newRank;
+
+    /**
+     * Тип повышения ранг
+     **/
+    @Column(name="type")
+    @Enumerated(EnumType.STRING)
+    private RankHistoryType type;
+
+    /**
+     * Причина изменения ранга (для типа Distributor)
+     */
+    @Column(name = "reason")
+    private String reason;
+}

--- a/src/main/java/com/itmo/goblinslayersystemserver/models/RankHistory.java
+++ b/src/main/java/com/itmo/goblinslayersystemserver/models/RankHistory.java
@@ -45,4 +45,18 @@ public class RankHistory extends BaseEntity {
      */
     @Column(name = "reason")
     private String reason;
+
+    /**
+     * Распределитель рангов, который выполнил изменение ранга (для типа Distributor)
+     **/
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "distributor")
+    private User distributor;
+
+    /**
+     * Контракт, благодаря которому был поднят ранг (для типа Auto)
+     **/
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "contract")
+    private Contract contract;
 }

--- a/src/main/java/com/itmo/goblinslayersystemserver/models/User.java
+++ b/src/main/java/com/itmo/goblinslayersystemserver/models/User.java
@@ -97,4 +97,11 @@ public class User extends BaseEntity {
      */
     @Column(name = "adventurer_reason")
     private String adventurerReason;
+
+    @OneToMany(mappedBy = "adventurer",
+            targetEntity=RankHistory.class,
+            cascade = CascadeType.ALL,
+            orphanRemoval = true,
+            fetch = FetchType.LAZY)
+    private List<RankHistory> rankHistories;
 }

--- a/src/main/java/com/itmo/goblinslayersystemserver/models/enums/RankHistoryType.java
+++ b/src/main/java/com/itmo/goblinslayersystemserver/models/enums/RankHistoryType.java
@@ -1,0 +1,13 @@
+package com.itmo.goblinslayersystemserver.models.enums;
+
+public enum RankHistoryType {
+    /**
+     * Ранг был распределен в автоматическом режиме при завершении контракта.
+     */
+    Auto,
+
+    /**
+     * Ранг был распределен в ручном режиме распределителем рангов.
+     */
+    Distributor
+}

--- a/src/main/java/com/itmo/goblinslayersystemserver/services/IUserService.java
+++ b/src/main/java/com/itmo/goblinslayersystemserver/services/IUserService.java
@@ -19,7 +19,9 @@ public interface IUserService {
 
     User get(Integer id);
     User get(String username);
-    Page<RankHistory> getAdventurerRankHistory();
+    Page<RankHistory> getAdventurerRankHistory(Integer id,
+                                               int pagePagination,
+                                               int sizePagination);
 
     User update(Integer id, User user);
     User update(Integer id, UserUpdateAdminDto user);

--- a/src/main/java/com/itmo/goblinslayersystemserver/services/IUserService.java
+++ b/src/main/java/com/itmo/goblinslayersystemserver/services/IUserService.java
@@ -1,6 +1,7 @@
 package com.itmo.goblinslayersystemserver.services;
 
 import com.itmo.goblinslayersystemserver.dto.*;
+import com.itmo.goblinslayersystemserver.models.RankHistory;
 import com.itmo.goblinslayersystemserver.models.User;
 import com.itmo.goblinslayersystemserver.models.enums.AdventurerRank;
 import com.itmo.goblinslayersystemserver.models.enums.AdventurerStatus;
@@ -18,6 +19,7 @@ public interface IUserService {
 
     User get(Integer id);
     User get(String username);
+    Page<RankHistory> getAdventurerRankHistory();
 
     User update(Integer id, User user);
     User update(Integer id, UserUpdateAdminDto user);

--- a/src/main/java/com/itmo/goblinslayersystemserver/services/IUserService.java
+++ b/src/main/java/com/itmo/goblinslayersystemserver/services/IUserService.java
@@ -24,6 +24,7 @@ public interface IUserService {
     User update(Integer id, User user);
     User update(Integer id, UserUpdateAdminDto user);
     User updateAdventurerStatus(Integer id, AdventurerStatus newStatus);
+    User updateAdventurerRank(Integer id, AdventurerRankUpdateDto adventurerRankUpdateDto, User distributor);
 
     void delete(Integer id);
 }

--- a/src/main/java/com/itmo/goblinslayersystemserver/services/implementation/UserService.java
+++ b/src/main/java/com/itmo/goblinslayersystemserver/services/implementation/UserService.java
@@ -7,6 +7,7 @@ import com.itmo.goblinslayersystemserver.dto.UserUpdateAdminDto;
 import com.itmo.goblinslayersystemserver.exceptions.BadRequestException;
 import com.itmo.goblinslayersystemserver.exceptions.NotFoundException;
 import com.itmo.goblinslayersystemserver.models.QUser;
+import com.itmo.goblinslayersystemserver.models.RankHistory;
 import com.itmo.goblinslayersystemserver.models.Role;
 import com.itmo.goblinslayersystemserver.models.User;
 import com.itmo.goblinslayersystemserver.models.enums.AdventurerRank;
@@ -23,6 +24,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 
 import java.util.ArrayList;
 import java.util.Optional;
@@ -238,6 +240,11 @@ public class UserService implements IUserService {
     @Override
     public User get(String username) {
         return userRepository.findByUsername(username);
+    }
+
+    @Override
+    public Page<RankHistory> getAdventurerRankHistory() {
+        throw new NotImplementedException();
     }
 
     @Override

--- a/src/main/resources/db/changelog/db.changelog-0.4.1.xml
+++ b/src/main/resources/db/changelog/db.changelog-0.4.1.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+
+    <changeSet id="add-adventurer-rank-history-table" author="paulrozhkin">
+        <createTable schemaName="public"
+                     tableName="rank_history">
+            <column name="id" type="serial" autoIncrement="true">
+                <constraints primaryKey="true"/>
+            </column>
+
+            <column name="adventurer" type="integer">
+                <constraints foreignKeyName="fk_rank_history_users" references="users(id)" nullable="false"/>
+            </column>
+
+            <column name="old_rank" type="text">
+                <constraints nullable="false"/>
+            </column>
+
+            <column name="new_rank" type="text">
+                <constraints nullable="false"/>
+            </column>
+
+            <column name="type" type="text">
+                <constraints nullable="false"/>
+            </column>
+
+            <column name="reason" type="text"/>
+
+            <column name="created" type="timestamp with time zone" defaultValue="now()">
+                <constraints nullable="false"/>
+            </column>
+
+            <column name="updated" type="timestamp with time zone" defaultValue="now()">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/db.changelog-0.4.1.xml
+++ b/src/main/resources/db/changelog/db.changelog-0.4.1.xml
@@ -30,6 +30,14 @@
 
             <column name="reason" type="text"/>
 
+            <column name="distributor" type="integer">
+                <constraints foreignKeyName="fk_rank_history_users_distributor" references="users(id)" nullable="true"/>
+            </column>
+
+            <column name="contract" type="integer">
+                <constraints foreignKeyName="fk_rank_history_contracts" references="contracts(id)" nullable="true"/>
+            </column>
+
             <column name="created" type="timestamp with time zone" defaultValue="now()">
                 <constraints nullable="false"/>
             </column>

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -8,5 +8,6 @@
     <include file="db/changelog/db.changelog-0.1.1.xml"/>
     <include file="db/changelog/db.changelog-0.3.0.xml"/>
     <include file="db/changelog/db.changelog-0.4.0.xml"/>
+    <include file="db/changelog/db.changelog-0.4.1.xml"/>
 </databaseChangeLog>
 


### PR DESCRIPTION
Добавлена таблица `rank_hostory`. В таблице находится история изменения рангов авантюриста. Ранг авантюриста может быть изменен двумя способами: автоматическим (`Auto`) и ручным (`Distributor`) через PUT запрос `/api/v1/adventurers/{id}/ranks/`. Запрос на ручное изменение доступен администратору и распределителю рангов. 
### Описание запроса:
Тело запроса:
```
{
  "newRank": "Emerald",
  "reason": "Too weak."
}
```
, где:
`newRank` - новый ранг, который будет присвоен авантюристу
`reason` - причина повышения/понижения ранга

Для получения истории изменения рангов введен запрос `/api/v1/adventurers/{id}/ranks/history/` по которому доступна полная история изменения рангов авантюриста. Запрос поддерживает пагинацию.
