### PR TITLE
Adventurer contract control

### DIFF
--- a/architecture/Database/schema.database
+++ b/architecture/Database/schema.database
@@ -47,6 +47,8 @@ Table contracts as CT {
   description               text
   customer_comment          text
   registrar_comment         text
+  performed_comment         text
+  cancellation_comment      text
   created                   timestamp
   updated                   timestamp
 }
@@ -101,7 +103,6 @@ Enum rank_type {
   Auto
   Distributor
 }
-
 
 Enum rank {
   Platinum    // adventurer_experience for rank - 10000

--- a/architecture/OpenApi/api.yaml
+++ b/architecture/OpenApi/api.yaml
@@ -1079,6 +1079,180 @@ paths:
               schema:
                 $ref: '#/components/schemas/errorModel'
 
+  /api/v1/contracts/{id}/perform/:
+    # Начать исполнение контракта авантюристом
+    post:
+      tags:
+        - contracts
+      operationId: startPerformContractByAdventurer
+      summary: Start performing contact
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          description: 'Contract ID.'
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: The adventurer model was updated successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/contract'
+        '400':
+          description: Bad Reaquest.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/errorModel'
+        '401':
+          description: Unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/errorModel'
+        '403':
+          description: "Forbidden. Only adventurer can start perform contact."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/errorModel'
+        '404':
+          description: Not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/errorModel'
+        '500':
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/errorModel'
+
+  /api/v1/contracts/{id}/performed/:
+    # Завершить исполнение контракта авантюристом
+    post:
+      tags:
+        - contracts
+      operationId: performedContractByAdventurer
+      summary: Stop performing contract if completed
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          description: 'Contract ID.'
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/contractPerformedModel'
+        required: true
+      responses:
+        '200':
+          description: The adventurer model was updated successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/contract'
+        '400':
+          description: Bad Reaquest.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/errorModel'
+        '401':
+          description: Unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/errorModel'
+        '403':
+          description: "Forbidden. Only adventurer can stop performing contact."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/errorModel'
+        '404':
+          description: Not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/errorModel'
+        '500':
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/errorModel'
+
+  /api/v1/contracts/{id}/cancel/:
+    # Отменить исполнение контракта текущим авантюристом
+    post:
+      tags:
+        - contracts
+      operationId: cancelContractByAdventurer
+      summary: Cancel contact
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          description: 'Contract ID.'
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/contractCancellationModel'
+        required: true
+      responses:
+        '200':
+          description: The contract was cancelled.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/contract'
+        '400':
+          description: Bad Reaquest.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/errorModel'
+        '401':
+          description: Unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/errorModel'
+        '403':
+          description: "Forbidden. Only adventurer, registrar and admin can cancel contact."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/errorModel'
+        '404':
+          description: Not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/errorModel'
+        '500':
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/errorModel'
+
 components:
   schemas:
 
@@ -1171,7 +1345,6 @@ components:
         - $ref: '#/components/schemas/credentials'
         - $ref: '#/components/schemas/userCommonInfo'
 
-
     userCreatableModel:
       allOf:
         - $ref: '#/components/schemas/credentials'
@@ -1180,7 +1353,6 @@ components:
     userUpdatableModel:
       allOf:
         - $ref: '#/components/schemas/userCommonInfoWithBlocked'
-
 
     userIdModel:
       type: object
@@ -1452,10 +1624,14 @@ components:
               description: 'Review of the Registrar.'
               type: string
               example: 'The abilities of goblins and Hobbs are not described.'
-            closedComment:
+            performedComment:
               description: 'Revocation of the adventurer is contract performance.'
               type: string
               example: 'All dead.'
+            cancellationComment:
+              description: 'Cancellation comment.'
+              type: string
+              example: 'The contract was too difficult.'
 
     notification:
       allOf:
@@ -1498,6 +1674,22 @@ components:
           type: string
           format: date-time
           example: '2017-07-21T17:32:28Z'
+
+    contractPerformedModel:
+      type: object
+      properties:
+        performedComment:
+          description: 'Unique identifier of the contractNotification.'
+          type: string
+          example: "All the goblins are killed."
+
+    contractCancellationModel:
+      type: object
+      properties:
+        cancellationComment:
+          description: 'Unique identifier of the contractNotification.'
+          type: string
+          example: "The contract was too difficult."
 
     errorModel:
       type: object

--- a/src/main/java/com/itmo/goblinslayersystemserver/config/SecurityConfig.java
+++ b/src/main/java/com/itmo/goblinslayersystemserver/config/SecurityConfig.java
@@ -1,7 +1,6 @@
 package com.itmo.goblinslayersystemserver.config;
 
 import com.itmo.goblinslayersystemserver.controllers.Endpoints;
-import com.itmo.goblinslayersystemserver.models.Role;
 import com.itmo.goblinslayersystemserver.security.jwt.JwtConfigurer;
 import com.itmo.goblinslayersystemserver.security.jwt.JwtTokenProvider;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,6 +18,13 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 @Configuration
 public class SecurityConfig extends WebSecurityConfigurerAdapter {
     private final JwtTokenProvider jwtTokenProvider;
+
+    private final String ROLE_ADMIN = "ADMIN";
+    private final String ROLE_CUSTOMER = "CUSTOMER";
+    private final String ROLE_ADVENTURER = "ADVENTURER";
+    private final String ROLE_REGISTRAR = "REGISTRAR";
+    private final String ROLE_DISTRIBUTOR = "DISTRIBUTOR";
+
 
     @Autowired
     public SecurityConfig(JwtTokenProvider jwtTokenProvider) {
@@ -40,9 +46,13 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .and()
                 .authorizeRequests()
                 .antMatchers(Endpoints.AuthenticationRestControllerV1).permitAll()
-                .antMatchers(Endpoints.AdminUserRestControllerV1).hasRole("ADMIN")
-                .antMatchers(Endpoints.AdventurersStatusUpdateRestControllerV1).hasAnyRole("ADMIN", "REGISTRAR")
-                .antMatchers(Endpoints.AdventurersRankUpdateRestControllerV1).hasAnyRole("ADMIN", "DISTRIBUTOR")
+                .antMatchers(Endpoints.AdminUserRestControllerV1).hasRole(ROLE_ADMIN)
+                .antMatchers(Endpoints.AdventurersStatusUpdateRestControllerV1).hasAnyRole(ROLE_ADMIN, ROLE_REGISTRAR)
+                .antMatchers(Endpoints.AdventurersRankUpdateRestControllerV1).hasAnyRole(ROLE_ADMIN, ROLE_DISTRIBUTOR)
+                .antMatchers(Endpoints.AdventurersRankUpdateRestControllerV1).hasAnyRole(ROLE_ADMIN, ROLE_DISTRIBUTOR)
+                .antMatchers(Endpoints.ContractPerformRestControllerV1).hasAnyRole(ROLE_ADMIN, ROLE_ADVENTURER)
+                .antMatchers(Endpoints.ContractPerformedRestControllerV1).hasAnyRole(ROLE_ADMIN, ROLE_ADVENTURER)
+                .antMatchers(Endpoints.ContractCancelRestControllerV1).hasAnyRole(ROLE_ADMIN, ROLE_ADVENTURER, ROLE_REGISTRAR)
                 .antMatchers(HttpMethod.POST, Endpoints.AdventurersRestControllerV1).permitAll()
                 .antMatchers(HttpMethod.POST, Endpoints.UsersRestControllerV1).permitAll()
                 .anyRequest().authenticated()

--- a/src/main/java/com/itmo/goblinslayersystemserver/controllers/ContractsRestControllerV1.java
+++ b/src/main/java/com/itmo/goblinslayersystemserver/controllers/ContractsRestControllerV1.java
@@ -1,17 +1,17 @@
 package com.itmo.goblinslayersystemserver.controllers;
 
-import com.itmo.goblinslayersystemserver.dto.ContractCreateDto;
-import com.itmo.goblinslayersystemserver.dto.ContractDto;
-import com.itmo.goblinslayersystemserver.dto.ContractUpdateDto;
-import com.itmo.goblinslayersystemserver.dto.ItemsDto;
+import com.itmo.goblinslayersystemserver.dto.*;
 import com.itmo.goblinslayersystemserver.models.Contract;
+import com.itmo.goblinslayersystemserver.models.User;
 import com.itmo.goblinslayersystemserver.models.enums.AdventurerRank;
 import com.itmo.goblinslayersystemserver.models.enums.ContractStatus;
 import com.itmo.goblinslayersystemserver.services.IContractService;
+import com.itmo.goblinslayersystemserver.services.IUserService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpServletResponse;
@@ -27,6 +27,9 @@ public class ContractsRestControllerV1 {
 
     @Autowired
     private IContractService contractService;
+
+    @Autowired
+    private IUserService userService;
 
     /**
      * Get запрос серверу для получения списка контрактов из системы
@@ -84,5 +87,32 @@ public class ContractsRestControllerV1 {
     @PutMapping(value = "/{id}", consumes = {"application/json"}, produces = {"application/json"})
     public ContractDto updateContract(@PathVariable Integer id, @RequestBody ContractUpdateDto contract) {
         return new ContractDto(contractService.update(id, contract));
+    }
+
+    /**
+     * Post запрос серверу для начала исполнения контракта авантюристом
+     **/
+    @PostMapping(value = "/{id}/perform/", consumes = {"application/json"}, produces = {"application/json"})
+    public ContractDto startPerformingContract(@PathVariable Integer id) {
+        String username = SecurityContextHolder.getContext().getAuthentication().getName();
+        User executor = userService.get(username);
+
+        return new ContractDto(contractService.startPerforming(id, executor));
+    }
+
+    /**
+     * Post запрос серверу для начала исполнения контракта авантюристом
+     **/
+    @PostMapping(value = "/{id}/performed/", consumes = {"application/json"}, produces = {"application/json"})
+    public ContractDto stopPerformingContract(@PathVariable Integer id, @RequestBody ContractPerformedDto commentDto) {
+        return new ContractDto(contractService.stopPerformingContract(id, commentDto.getPerformedComment()));
+    }
+
+    /**
+     * Post запрос серверу для отмены исполнения контракта авантюристом
+     **/
+    @PostMapping(value = "/{id}/cancel/", consumes = {"application/json"}, produces = {"application/json"})
+    public ContractDto cancelContract(@PathVariable Integer id, @RequestBody ContractCancelDto commentDto) {
+        return new ContractDto(contractService.cancelContract(id, commentDto.getCancellationComment()));
     }
 }

--- a/src/main/java/com/itmo/goblinslayersystemserver/controllers/Endpoints.java
+++ b/src/main/java/com/itmo/goblinslayersystemserver/controllers/Endpoints.java
@@ -12,4 +12,8 @@ public class Endpoints {
     // specific endpoints
     public static final String AdventurersStatusUpdateRestControllerV1 = AdventurersRestControllerV1 + "{id}/status/";
     public static final String AdventurersRankUpdateRestControllerV1 = AdventurersRestControllerV1 + "{id}/ranks/";
+
+    public static final String ContractPerformRestControllerV1 = ContractsRestControllerV1 + "{id}/perform/";
+    public static final String ContractPerformedRestControllerV1 = ContractsRestControllerV1 + "{id}/performed/";
+    public static final String ContractCancelRestControllerV1 = ContractsRestControllerV1 + "{id}/cancel/";
 }

--- a/src/main/java/com/itmo/goblinslayersystemserver/dto/ContractCancelDto.java
+++ b/src/main/java/com/itmo/goblinslayersystemserver/dto/ContractCancelDto.java
@@ -1,0 +1,13 @@
+package com.itmo.goblinslayersystemserver.dto;
+
+import lombok.Data;
+import lombok.NonNull;
+
+@Data
+public class ContractCancelDto {
+    @NonNull
+    private String cancellationComment;
+
+    // for deserialization
+    public ContractCancelDto() {}
+}

--- a/src/main/java/com/itmo/goblinslayersystemserver/dto/ContractDto.java
+++ b/src/main/java/com/itmo/goblinslayersystemserver/dto/ContractDto.java
@@ -45,7 +45,9 @@ public class ContractDto {
 
     private String registrarComment;
 
-    private String closedComment;
+    private String performedComment;
+
+    private String cancellationComment;
 
     public ContractDto(Contract contract) {
         id = contract.getId();
@@ -60,6 +62,7 @@ public class ContractDto {
         description = contract.getDescription();
         requestComment = contract.getRequestComment();
         registrarComment = contract.getRegistrarComment();
-        closedComment = contract.getClosedComment();
+        performedComment = contract.getPerformedComment();
+        cancellationComment = contract.getCancellationComment();
     }
 }

--- a/src/main/java/com/itmo/goblinslayersystemserver/dto/ContractPerformedDto.java
+++ b/src/main/java/com/itmo/goblinslayersystemserver/dto/ContractPerformedDto.java
@@ -1,0 +1,14 @@
+package com.itmo.goblinslayersystemserver.dto;
+
+import com.itmo.goblinslayersystemserver.models.enums.AdventurerStatus;
+import lombok.Data;
+import lombok.NonNull;
+
+@Data
+public class ContractPerformedDto {
+    @NonNull
+    private String performedComment;
+
+    // for deserialization
+    public ContractPerformedDto() {}
+}

--- a/src/main/java/com/itmo/goblinslayersystemserver/models/Contract.java
+++ b/src/main/java/com/itmo/goblinslayersystemserver/models/Contract.java
@@ -86,10 +86,16 @@ public class Contract extends BaseEntity {
     private String registrarComment;
 
     /**
-     * Комментарий авантюриста при закрытии контракта
+     * Комментарий авантюриста при завершении контракта
      **/
-    @Column(name="closed_comment")
-    private String closedComment;
+    @Column(name="performed_comment")
+    private String performedComment;
+
+    /**
+     * Комментарий авантюриста при отмене контракта
+     **/
+    @Column(name="cancellation_comment")
+    private String cancellationComment;
 
     /**
      * Оповещения об изменении статуса контракта.

--- a/src/main/java/com/itmo/goblinslayersystemserver/models/enums/AdventurerRank.java
+++ b/src/main/java/com/itmo/goblinslayersystemserver/models/enums/AdventurerRank.java
@@ -38,6 +38,15 @@ public enum AdventurerRank {
      }
 
      /**
+      * Сравнивает два ранга на меньшинство.
+      * @param rank ранг-параметр.
+      * @return Возвращает true, если ранг меньше по приоритету.
+      */
+     public boolean IsLess(AdventurerRank rank) {
+          return this.getExperienceRequired() < rank.getExperienceRequired();
+     }
+
+     /**
       * Возвращает ранги, которые являются меньше, чем передаваемый ранг (сам ранг тоже входит в коллекцию).
       * @param rank анализируемый ранг.
       * @return Коллекция рангов, которые меньше, либо равны по приоритету.

--- a/src/main/java/com/itmo/goblinslayersystemserver/services/IContractService.java
+++ b/src/main/java/com/itmo/goblinslayersystemserver/services/IContractService.java
@@ -3,6 +3,7 @@ package com.itmo.goblinslayersystemserver.services;
 import com.itmo.goblinslayersystemserver.dto.ContractCreateDto;
 import com.itmo.goblinslayersystemserver.dto.ContractUpdateDto;
 import com.itmo.goblinslayersystemserver.models.Contract;
+import com.itmo.goblinslayersystemserver.models.User;
 import com.itmo.goblinslayersystemserver.models.enums.AdventurerRank;
 import com.itmo.goblinslayersystemserver.models.enums.ContractStatus;
 import org.springframework.data.domain.Page;
@@ -15,11 +16,18 @@ public interface IContractService {
                        ContractStatus contractStatusFilter,
                        int pagePagination,
                        int sizePagination);
+    Contract get(Integer id);
 
     Contract create(Contract contract);
     Contract create(ContractCreateDto contract);
-    Contract get(Integer id);
+
     Contract update(Integer id, Contract contract);
     Contract update(Integer id, ContractUpdateDto contract);
+
     void delete(Integer id);
+
+    // specific methods
+    Contract startPerforming(Integer id, User executor);
+    Contract stopPerformingContract(Integer id, String performedComment);
+    Contract cancelContract(Integer id, String cancellationComment);
 }

--- a/src/main/java/com/itmo/goblinslayersystemserver/services/implementation/ContractService.java
+++ b/src/main/java/com/itmo/goblinslayersystemserver/services/implementation/ContractService.java
@@ -5,6 +5,7 @@ import com.itmo.goblinslayersystemserver.dto.ContractUpdateDto;
 import com.itmo.goblinslayersystemserver.exceptions.NotFoundException;
 import com.itmo.goblinslayersystemserver.models.Contract;
 import com.itmo.goblinslayersystemserver.models.QContract;
+import com.itmo.goblinslayersystemserver.models.User;
 import com.itmo.goblinslayersystemserver.models.enums.AdventurerRank;
 import com.itmo.goblinslayersystemserver.models.enums.ContractStatus;
 import com.itmo.goblinslayersystemserver.repositories.ContractRepository;
@@ -16,6 +17,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 
 import java.util.Optional;
 
@@ -141,5 +143,20 @@ public class ContractService implements IContractService {
     @Override
     public void delete(Integer id) {
         contractRepository.deleteById(id);
+    }
+
+    @Override
+    public Contract startPerforming(Integer id, User executor) {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public Contract stopPerformingContract(Integer id, String performedComment) {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public Contract cancelContract(Integer id, String cancellationComment) {
+        throw new NotImplementedException();
     }
 }

--- a/src/main/java/com/itmo/goblinslayersystemserver/services/implementation/ContractService.java
+++ b/src/main/java/com/itmo/goblinslayersystemserver/services/implementation/ContractService.java
@@ -117,7 +117,7 @@ public class ContractService implements IContractService {
         contract.setDescription(update.getDescription());
         contract.setRequestComment(update.getRequestComment());
         contract.setRegistrarComment(update.getRegistrarComment());
-        contract.setClosedComment(update.getClosedComment());
+        contract.setPerformedComment(update.getPerformedComment());
         contractRepository.save(contract);
 
         return get(contract.getId());
@@ -134,7 +134,7 @@ public class ContractService implements IContractService {
         contract.setDescription(update.getDescription());
         contract.setRequestComment(update.getRequestComment());
         contract.setRegistrarComment(update.getRegistrarComment());
-        contract.setClosedComment(update.getClosedComment());
+        contract.setPerformedComment(update.getClosedComment());
         return update(id, contract);
     }
 

--- a/src/main/java/com/itmo/goblinslayersystemserver/services/implementation/ContractService.java
+++ b/src/main/java/com/itmo/goblinslayersystemserver/services/implementation/ContractService.java
@@ -2,11 +2,13 @@ package com.itmo.goblinslayersystemserver.services.implementation;
 
 import com.itmo.goblinslayersystemserver.dto.ContractCreateDto;
 import com.itmo.goblinslayersystemserver.dto.ContractUpdateDto;
+import com.itmo.goblinslayersystemserver.exceptions.BadRequestException;
 import com.itmo.goblinslayersystemserver.exceptions.NotFoundException;
 import com.itmo.goblinslayersystemserver.models.Contract;
 import com.itmo.goblinslayersystemserver.models.QContract;
 import com.itmo.goblinslayersystemserver.models.User;
 import com.itmo.goblinslayersystemserver.models.enums.AdventurerRank;
+import com.itmo.goblinslayersystemserver.models.enums.AdventurerStatus;
 import com.itmo.goblinslayersystemserver.models.enums.ContractStatus;
 import com.itmo.goblinslayersystemserver.repositories.ContractRepository;
 import com.itmo.goblinslayersystemserver.services.IContractService;
@@ -17,7 +19,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
-import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 
 import java.util.Optional;
 
@@ -147,16 +148,77 @@ public class ContractService implements IContractService {
 
     @Override
     public Contract startPerforming(Integer id, User executor) {
-        throw new NotImplementedException();
+        Optional<Contract> contractOptional = contractRepository.findById(id);
+        if (!contractOptional.isPresent()) {
+            throw new NotFoundException();
+        }
+
+        Contract contract = contractOptional.get();
+
+        if (contract.getContractStatus() != ContractStatus.Accepted) {
+            throw new BadRequestException("Contract have invalid status for start performing (must be Accepted) - " + contract.getContractStatus());
+        }
+
+        if (contract.getExecutor() != null) {
+            throw new BadRequestException("Contract already have executor id - " + contract.getExecutor());
+        }
+
+        if (executor.getAdventurerRank().IsLess(contract.getMinRank())) {
+            throw new BadRequestException("Adventurer can't start performing. Minimum rank is - " + contract.getMinRank());
+        }
+
+        if (executor.getAdventurerStatus() != AdventurerStatus.Active) {
+            throw new BadRequestException("Adventurer can't start performing. He's not active - " + executor.getAdventurerStatus());
+        }
+
+        contract.setExecutor(executor.getId());
+        contract.setContractStatus(ContractStatus.Performing);
+        contract.setCancellationComment(null);
+        contractRepository.save(contract);
+
+        return get(id);
     }
 
     @Override
     public Contract stopPerformingContract(Integer id, String performedComment) {
-        throw new NotImplementedException();
+        Optional<Contract> contractOptional = contractRepository.findById(id);
+        if (!contractOptional.isPresent()) {
+            throw new NotFoundException();
+        }
+
+        Contract contract = contractOptional.get();
+
+        if (contract.getContractStatus() != ContractStatus.Performing) {
+            throw new BadRequestException("Contract have invalid status for start performing (must be Performing) - " + contract.getContractStatus());
+        }
+
+        contract.setContractStatus(ContractStatus.Performed);
+        contract.setPerformedComment(performedComment);
+        contract.setCancellationComment(null);
+        contractRepository.save(contract);
+
+        return get(id);
     }
 
     @Override
     public Contract cancelContract(Integer id, String cancellationComment) {
-        throw new NotImplementedException();
+        Optional<Contract> contractOptional = contractRepository.findById(id);
+        if (!contractOptional.isPresent()) {
+            throw new NotFoundException();
+        }
+
+        Contract contract = contractOptional.get();
+
+        if (contract.getContractStatus() != ContractStatus.Performing) {
+            throw new BadRequestException("Contract have invalid status for cancel performing (must be Performing) - " + contract.getContractStatus());
+        }
+
+        contract.setContractStatus(ContractStatus.Accepted);
+        contract.setCancellationComment(cancellationComment);
+        contract.setExecutor(null);
+        contract.setPerformedComment(null);
+        contractRepository.save(contract);
+
+        return get(id);
     }
 }

--- a/src/main/resources/db/changelog/db.changelog-0.4.2.xml
+++ b/src/main/resources/db/changelog/db.changelog-0.4.2.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+
+    <changeSet id="add-new-columns-for-adventurer-contract-management" author="paulrozhkin">
+        <addColumn schemaName="public"
+                   tableName="contracts">
+            <column name="cancellation_comment"
+                    position="12"
+                    type="text"/>
+        </addColumn>
+
+        <renameColumn columnDataType="text"
+                      newColumnName="performed_comment"
+                      oldColumnName="closed_comment"
+                      schemaName="public"
+                      tableName="contracts"/>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -9,5 +9,6 @@
     <include file="db/changelog/db.changelog-0.3.0.xml"/>
     <include file="db/changelog/db.changelog-0.4.0.xml"/>
     <include file="db/changelog/db.changelog-0.4.1.xml"/>
+    <include file="db/changelog/db.changelog-0.4.2.xml"/>
 </databaseChangeLog>
 


### PR DESCRIPTION
Добавлено управление контрактами, для этого введены следующие endpoints:
1) POST `/api/v1/contracts/{id}/perform/`
Запрос для начала исполнения контракта авантюристом. Доступна только для авантюристов. При отправке запроса происходит проверка авантюриста по следующим критериям:
  * Статус контракта `Accepted`
  * Исполнитель контракта отсутствует
  * Ранг авантюриста, отправившего запрос, больше минимального ранга контракт
  * Статус авантюриста отправившего запрос `Active`
При соблюдении всех условий контракту выставляется исполнитель (авантюрист, отправивший запрос), статус контракта становится `Performing` и стирается комментарий отмены.
2) POST  `/api/v1/contracts/{id}/performed/`
Запрос для завершения исполнения контракта (задание выполнено). Доступен только для авантюристов. Запрос содержит тело следующего вида:
```
{
  "performedComment": "All the goblins are killed."
}
```
При отправке запроса происходит проверка авантюриста по следующим критериям:
  * Статус контракта `Performing`
При соблюдении всех условий контракту выставляется `performedComment` и статус `Performed`.
3) POST  `/api/v1/contracts/{id}/cancel/`
Запрос для отмены исполнения контракта. Доступен авантюристу и регистратору. Запрос содержит тело следующего вида:
```
{
  "cancellationComment": "The contract was too difficult."
}
```
При отправке запроса происходит проверка авантюриста по следующим критериям:
  * Статус контракта `Performing`
При соблюдении всех условий контракту выставляется `cancellationComment` и статус `Accepted`,  а `executor` становится null.