### PR TITLE
Account information update

### DIFF
--- a/architecture/OpenApi/api.yaml
+++ b/architecture/OpenApi/api.yaml
@@ -838,6 +838,95 @@ paths:
               schema:
                 $ref: '#/components/schemas/errorModel'
 
+    # Обновить персональную информацию
+    put:
+      tags:
+        - account
+      operationId: updateAccountInformation
+      summary: Update the account information
+      security:
+        - bearerAuth: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/accountUpdateInfo'
+        required: true
+      responses:
+        '200':
+          description: The account was updated successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/user'
+        '400':
+          description: Bad Reaquest.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/errorModel'
+        '401':
+          description: Unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/errorModel'
+        '404':
+          description: Not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/errorModel'
+        '500':
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/errorModel'
+
+  /api/v1/account/password/:
+    # Обновить пароль пользователя
+    put:
+      tags:
+        - account
+      operationId: updateAccountPassword
+      summary: Update the password
+      security:
+        - bearerAuth: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/passwordUpdateInfo'
+        required: true
+      responses:
+        '200':
+          description: The password was updated successfully.
+        '400':
+          description: Bad Reaquest.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/errorModel'
+        '401':
+          description: Unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/errorModel'
+        '404':
+          description: Not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/errorModel'
+        '500':
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/errorModel'
+
   /api/v1/contracts/:
     #Получение списка всех контрактов
     get:
@@ -1686,6 +1775,22 @@ components:
           description: 'Unique identifier of the contractNotification.'
           type: string
           example: "The contract was too difficult."
+
+    accountUpdateInfo:
+      allOf:
+        - $ref: '#/components/schemas/userCommonInfoWithoutRoles'
+
+    passwordUpdateInfo:
+      type: object
+      properties:
+        oldPassword:
+          description: 'Old password for validation.'
+          type: string
+          example: "passwordOld123"
+        newPassword:
+          description: 'New password.'
+          type: string
+          example: "passwordNew456"
 
     errorModel:
       type: object

--- a/src/main/java/com/itmo/goblinslayersystemserver/controllers/AccountRestControllerV1.java
+++ b/src/main/java/com/itmo/goblinslayersystemserver/controllers/AccountRestControllerV1.java
@@ -1,5 +1,7 @@
 package com.itmo.goblinslayersystemserver.controllers;
 
+import com.itmo.goblinslayersystemserver.dto.AccountPasswordUpdateDto;
+import com.itmo.goblinslayersystemserver.dto.AccountUpdateDto;
 import com.itmo.goblinslayersystemserver.dto.NotificationDto;
 import com.itmo.goblinslayersystemserver.dto.UserDto;
 import com.itmo.goblinslayersystemserver.models.User;
@@ -27,6 +29,24 @@ public class AccountRestControllerV1 {
     public UserDto getCurrentUser() {
         String username = SecurityContextHolder.getContext().getAuthentication().getName();
         return new UserDto(userService.get(username));
+    }
+
+    /**
+     * Get запрос серверу для обнолвнеия данных текущего пользователя
+     **/
+    @PutMapping(consumes = {"application/json"}, produces = {"application/json"})
+    public UserDto updateCurrentUser(@RequestBody AccountUpdateDto accountUpdateDto) {
+        String username = SecurityContextHolder.getContext().getAuthentication().getName();
+        return new UserDto(userService.update(username, accountUpdateDto));
+    }
+
+    /**
+     * Get запрос серверу для обнолвнеия данных текущего пользователя
+     **/
+    @PutMapping(value = "/password/", consumes = {"application/json"}, produces = {"application/json"})
+    public UserDto updatePasswordCurrentUser(@RequestBody AccountPasswordUpdateDto passwordUpdateDto) {
+        String username = SecurityContextHolder.getContext().getAuthentication().getName();
+        return new UserDto(userService.updatePassword(username, passwordUpdateDto));
     }
 
     /**

--- a/src/main/java/com/itmo/goblinslayersystemserver/dto/AccountPasswordUpdateDto.java
+++ b/src/main/java/com/itmo/goblinslayersystemserver/dto/AccountPasswordUpdateDto.java
@@ -1,0 +1,12 @@
+package com.itmo.goblinslayersystemserver.dto;
+
+import lombok.Data;
+import lombok.NonNull;
+
+@Data
+public class AccountPasswordUpdateDto {
+    @NonNull
+    private String oldPassword;
+    @NonNull
+    private String newPassword;
+}

--- a/src/main/java/com/itmo/goblinslayersystemserver/dto/AccountUpdateDto.java
+++ b/src/main/java/com/itmo/goblinslayersystemserver/dto/AccountUpdateDto.java
@@ -1,0 +1,12 @@
+package com.itmo.goblinslayersystemserver.dto;
+
+import lombok.Data;
+import lombok.NonNull;
+
+@Data
+public class AccountUpdateDto {
+    @NonNull
+    private String name;
+    @NonNull
+    private String address;
+}

--- a/src/main/java/com/itmo/goblinslayersystemserver/services/IUserService.java
+++ b/src/main/java/com/itmo/goblinslayersystemserver/services/IUserService.java
@@ -28,6 +28,8 @@ public interface IUserService {
     User updateAdventurerStatus(Integer id, AdventurerStatus newStatus);
     User updateAdventurerRank(Integer id, AdventurerRankUpdateDto adventurerRankUpdateDto, User distributor);
     User updateAdventurerRank(Integer id, Integer experience);
+    User update(String username, AccountUpdateDto accountUpdateDto);
+    User updatePassword(String username, AccountPasswordUpdateDto passwordUpdateDto);
 
     void delete(Integer id);
 }

--- a/src/main/java/com/itmo/goblinslayersystemserver/services/implementation/UserService.java
+++ b/src/main/java/com/itmo/goblinslayersystemserver/services/implementation/UserService.java
@@ -204,6 +204,32 @@ public class UserService implements IUserService {
     }
 
     @Override
+    public User update(String username, AccountUpdateDto accountUpdateDto) {
+        User user = get(username);
+
+        user.setName(accountUpdateDto.getName());
+        user.setAddress(accountUpdateDto.getAddress());
+
+        userRepository.save(user);
+
+        return get(user.getId());
+    }
+
+    @Override
+    public User updatePassword(String username, AccountPasswordUpdateDto passwordUpdateDto) {
+        User user = get(username);
+
+        if (!passwordEncoder.matches(passwordUpdateDto.getOldPassword(), user.getPassword())) {
+            throw new BadRequestException("Incorrect password entered.");
+        }
+
+        user.setPassword(passwordEncoder.encode(passwordUpdateDto.getNewPassword()));
+        userRepository.save(user);
+
+        return get(user.getId());
+    }
+
+    @Override
     public User create(UserCreateDto user) {
         Role customerRole = rolesService.get(RoleEnum.ROLE_CUSTOMER);
         ArrayList<Role> userRoles = new ArrayList<>();


### PR DESCRIPTION
Добавлено два PUT метода в API для обновления информации об аккаунте:
1) PUT `/api/v1/account/` с телом:
```
{
  "name": "Rozkin Pavel Aleksandrovich",
  "address": "Russia, Moscow"
}
```
Используется для обновления основной информации об аккаунте.
2) PUT `/api/v1/account/password/` с телом:
```
{
  "oldPassword": "passwordOld123",
  "newPassword": "passwordNew456"
}
```
Используется для обновления пароля аккаунта. Проверяет равенство текущего пароля пользователя с передаваемым и если они равны, то устанавливает пользователю новый пароль, который должен быть использован при следующей авторизации.
